### PR TITLE
Nauty performance and correctness issue resolution

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 Nauty = "078ca17e-7fb0-5a15-af2c-e86ea292e9a4"
 PermutationGroups = "8bc5a954-2dfc-11e9-10e6-cd969bffa420"

--- a/src/CSetAutomorphisms.jl
+++ b/src/CSetAutomorphisms.jl
@@ -1,8 +1,8 @@
 module CSetAutomorphisms
 
 export common, canonical_hash, apply_automorphism, autos, CDict, to_vizstate,
-       color_saturate, canonical_hash_nauty, init_graphs, test_iso,
-       graph_to_cset
+       color_saturate, canonical_iso_nauty, init_graphs, test_iso, to_lg,
+       graph_to_cset, graph_to_lg, Labeled, TheoryDecGraph
 
 include("./Perms.jl")
 include("./ColorRefine.jl")

--- a/src/Canonical.jl
+++ b/src/Canonical.jl
@@ -156,7 +156,8 @@ end
 Compute automorphisms for the pseudo-cset, but then substitute in
 the actual attribute values before evaluating the lexicographic order
 """
-function canonical_iso(g::StructACSet{S})::StructACSet{S} where {S}
+function canonical_iso(g::StructACSet{S}; pres::Union{Nothing,Presentation})::StructACSet{S} where {S}
+  if !isnothing(pres) return canonical_iso_nauty(g, pres) end
   os = order_syms(g)
   ord(x) = vcat([x[a] for a in attr(S)],[x[s] for s in os])
 
@@ -168,8 +169,7 @@ end
 """Hash of canonical isomorphism."""
 function canonical_hash(g::StructACSet;
                         pres::Union{Nothing,Presentation}=nothing)::UInt64
-  (isnothing(pres) ? hash(string(canonical_iso(g)))
-                   : canonical_hash_nauty(g, pres))
+  hash(string(canonical_iso(g; pres=pres)))
 end
 
 """Find index at which two vectors diverge (used in `search_tree`)"""

--- a/src/NautyInterface.jl
+++ b/src/NautyInterface.jl
@@ -150,7 +150,14 @@ end
 """Convert to Nauty.jl input, then interpret result back into Catlab language"""
 function canonical_iso_nauty(g::StructACSet, p::Presentation)::StructACSet
   lgrph, lab, prt, _, _ = to_lg(g, p)
-  cf = Nauty.baked_canonical_form_color(lgrph, lab, prt).canong
+  cf = coloured_digraph_canonical_form(lgrph, lab, prt)
   return from_canong(cf, p, g)
 end
 
+"""Digraph isomorphism testing in Nauty.jl"""
+function coloured_digraph_canonical_form(g, labels, partition)
+  options = Nauty.doptionblk_mutable()
+  options.defaultptn = false
+  options.getcanon = true
+  return Nauty.densenauty(Nauty.lg_to_nauty(g), options, labels, partition).canong
+end

--- a/src/TestHelp.jl
+++ b/src/TestHelp.jl
@@ -53,9 +53,7 @@ function test_iso(a::StructACSet,b::StructACSet, pres::Union{Nothing,Presentatio
   eq = is_isomorphic(a,b)
   tst = (x,y) -> eq ? x==y : x!=y # hashes should be equal iff they're iso
   if !isnothing(pres)
-    println("Starting nauty test on $a")
     @test tst(canonical_hash(a,pres=pres), canonical_hash(b; pres=pres))
-    println("finished")
   end
   @test tst(canonical_hash(a), canonical_hash(b))
 end

--- a/test/test.jl
+++ b/test/test.jl
@@ -84,20 +84,10 @@ catschema = @acset Graph begin
 end
 random_perm = Dict([:V=>randperm(7), :E=>randperm(17)])
 catschema2 = apply_automorphism(catschema, random_perm)
-test_iso(catschema,catschema2)
+test_iso(catschema,catschema2, TheoryGraph)
 
-# ACSet tests
-@present TheoryDecGraph(FreeSchema) begin
-  E::Ob
-  V::Ob
-  src::Hom(E,V)
-  tgt::Hom(E,V)
-
-  X::AttrType
-  dec::Attr(E,X)
-end
-
-@acset_type Labeled(TheoryDecGraph)
+# ACSet Tests
+#############
 
 G = @acset Labeled{String} begin
   V = 4


### PR DESCRIPTION
These changes are made in coordination with the [changes](https://github.com/kris-brown/Nauty.jl/commit/cce96b6583c0eb48318c7a4bee144220cf8f4a9d) made in a new fork to Nauty.jl. The interface given in the main repo for `Nauty.jl` only works for symmetric graphs. Furthermore,  a compilation flag is changed for `nauty.c` that allows for graphs with more than 64 vertices to be used.