### PR TITLE
Warn when call_nauty is used on attributed C-sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [Attributed C-sets](https://arxiv.org/pdf/2106.04703.pdf) encompass a broad class of data structures, including many generalizations of graphs (e.g. [directed](https://www.algebraicjulia.org/blog/post/2020/09/cset-graphs-1/), [symmetric](https://www.algebraicjulia.org/blog/post/2020/09/cset-graphs-2), [reflexive](https://www.algebraicjulia.org/blog/post/2021/04/cset-graphs-3/)), tabular data (e.g. [data frames](https://pandas.pydata.org/pandas-docs/stable/user_guide/dsintro.html)), and combinations of the two (e.g. weighted graphs, [relational databases](https://en.wikiversity.org/wiki/Relational_Databases/Introduction)). This repo generalizes the [Nauty](https://pallini.di.uniroma1.it/Introduction.html) algorithm, which produces canonical members of an isomorphism class, to cover any data structure encompassed by C-Sets. Furthermore, we compute and represent orbits and full automorphism groups of a C-Set, which can be applied to solving certain problems (e.g. searching for homomorphisms from A to B, up to isomorphism).
 
-More background is found in the documentation (click above) or this [blog](https://www.algebraicjulia.org/blog/post/2022/01/cset-automorphisms/) post.
+More background is found in the [documentation](https://algebraicjulia.github.io/CSetAutomorphisms.jl/dev/) or this [blog](https://www.algebraicjulia.org/blog/post/2022/01/cset-automorphisms/) post.
 
 ## To do
 - An upcoming refactor of Catlab using [CompTime.jl](https://github.com/olynch/CompTime.jl) will make it feasible to reimplement the core algorithm using code custom generated for a given C-Set, offering new opportunities for performance improvements.
+- For now, it is recommended to just use `NautyInterface` which reduces a C-Set automorphism problem to an undirected multigraph automorphism problem, which is fed `nauty.c`.
 

--- a/src/NautyInterface.jl
+++ b/src/NautyInterface.jl
@@ -2,6 +2,7 @@ module NautyInterface
 export call_nauty, all_autos
 
 using Catlab.CategoricalAlgebra, Catlab.Present, Catlab.Graphs
+using Catlab.Theories: attr
 using DataStructures: OrderedSet, DefaultDict
 using Permutations
 import Base: (*)
@@ -68,6 +69,9 @@ Make shell command to dreadnaut and collect output
 """
 function call_nauty(g::StructACSet{S}; check=false) where S
   if g == typeof(g)() return NautyRes(g) end
+  if !isempty(attr(S))
+    @warn "Attributes are currently unsupported by call_nauty - ignoring them"
+  end
   m,oinds,_ = to_adj(g)
 
   # Run nauty and collect output as a string

--- a/test/Canonical.jl
+++ b/test/Canonical.jl
@@ -7,7 +7,7 @@ using CSetAutomorphisms
 using CSetAutomorphisms.NautyInterface: all_autos
 using CSetAutomorphisms.Canonical: common
 using CSetAutomorphisms.Perms: apply_automorphism
-using CSetAutomorphisms.TestHelp: test_iso, init_graphs
+using CSetAutomorphisms.TestHelp: test_iso, init_graphs, Labeled
 
 
 using Random
@@ -119,75 +119,43 @@ catschema2 = apply_automorphism(catschema, random_perm)
 test_iso(catschema,catschema2)
 
 
-# ACSet Tests - to be supported in the future
-#############################################
-if false
+# ACSet Tests - to be supported by call_nauty in the future
+###########################################################
 G = @acset Labeled{String} begin
-  V = 4
-  E = 4
-  src = [1,2,3,4]
-  tgt = [2,3,4,1]
-  dec = ["a","b","c","d"]
+  V = 4; E = 4; src = [1,2,3,4]; tgt = [2,3,4,1]; dec = ["a","b","c","d"]
 end;
 
 
 H = @acset Labeled{String} begin
-  V = 4
-  E = 4
-  src = [1,3,2,4]
-  tgt = [3,2,4,1]
-  dec = ["a","b","c","d"]
+  V = 4; E = 4; src = [1,3,2,4]; tgt = [3,2,4,1]; dec = ["a","b","c","d"]
 end;
 
-test_iso(G, H) # vertices permuted
+@test canonical_hash(G) == canonical_hash(H)
 
 I = @acset Labeled{String} begin
-V = 4
-E = 4
-src = [1,2,3,4]
-tgt = [2,3,4,1]
-dec = ["b","c","d","a"]
+  V = 4; E = 4; src = [1,2,3,4]; tgt = [2,3,4,1]; dec = ["b","c","d","a"]
 end;
-
-test_iso(G, I) # labels permuted
 
 N = @acset Labeled{String} begin
-  V = 4
-  E = 4
-  src = [1,2,3,4]
-  tgt = [2,3,4,1]
-  dec = ["a","a","b","c"]
+  V = 4; E = 4; src = [1,2,3,4]; tgt = [2,3,4,1]; dec = ["a","a","b","c"]
 end;
 
-test_iso(G,N) # label mismatch
+@test canonical_hash(G) != canonical_hash(N)
 
 K = @acset Labeled{String} begin
-  V = 4
-  E = 4
-  src = [1,3,2,4]
-  tgt = [2,3,4,1]
-  dec = ["a","d","b","c"]
+  V = 4; E = 4; src = [1,3,2,4]; tgt = [2,3,4,1]; dec = ["a","d","b","c"]
 end;
 
-test_iso(G, K) # vertex mismatch
+@test canonical_hash(G) != canonical_hash(K)
 
 G1 = @acset Labeled{String} begin
-  V = 1
-  E = 1
-  src = [1]
-  tgt = [1]
-  dec = ["a"]
+  V = 1; E = 1; src = [1]; tgt = [1]; dec = ["a"]
 end;
 
 H1 = @acset Labeled{String} begin
-  V = 1
-  E = 1
-  src = [1]
-  tgt = [1]
-  dec = ["b"]
+  V = 1; E = 1; src = [1]; tgt = [1]; dec = ["b"]
 end;
 
-test_iso(G1, H1) # label values different
-end
+@test canonical_hash(G1) != canonical_hash(H1)
 
 end # module


### PR DESCRIPTION
call_nauty currently doesn't support incorporating attribute data - it just ignores them. 

It could still be useful to obtain canonical data for the purely-combinatorial portion of an ACSet, but this warning is an important caveat.

Also tests which show that the pure-Julia implementation works on attributes have been uncommented.